### PR TITLE
Added Hotfixes ingress and https

### DIFF
--- a/auth/src/app.ts
+++ b/auth/src/app.ts
@@ -15,7 +15,8 @@ app.use(json());
 app.use(
     cookieSession({
         signed: false,
-        secure: process.env.NODE_ENV !== 'test'
+        //secure: process.env.NODE_ENV !== 'test'
+        secure: false
     })
 );
 

--- a/characters/src/app.ts
+++ b/characters/src/app.ts
@@ -14,7 +14,8 @@ app.use(json());
 app.use(
     cookieSession({
         signed: false,
-        secure: process.env.NODE_ENV !== 'test'
+        //secure: process.env.NODE_ENV !== 'test'
+        secure: false
     })
 );
 app.use(currentUser);

--- a/client/api/buildClient.js
+++ b/client/api/buildClient.js
@@ -4,7 +4,7 @@ const BuildClient = ({req}) => {
     if(typeof window === 'undefined'){
         // Server side
         return axios.create({
-            baseURL: 'http://ingress-nginx-controller.ingress-nginx.svc.cluster.local',
+            baseURL: 'http://www.saon-beta.xyz/',
             headers: req.headers
         });
     } else {

--- a/gmchanges/src/app.ts
+++ b/gmchanges/src/app.ts
@@ -14,7 +14,8 @@ app.use(json());
 app.use(
     cookieSession({
         signed: false,
-        secure: process.env.NODE_ENV !== 'test'
+        //secure: process.env.NODE_ENV !== 'test'
+        secure: false
     })
 );
 app.use(currentUser);

--- a/infra/k8s-prod/ingress-srv.yaml
+++ b/infra/k8s-prod/ingress-srv.yaml
@@ -30,3 +30,35 @@ spec:
             backend:
               serviceName: client-srv
               servicePort: 3000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.beta.kubernetes.io/do-loadbalancer-enable-proxy-protocol: 'true'
+    service.beta.kubernetes.io/do-loadbalancer-hostname: 'www.saon-beta.xyz'
+  labels:
+    helm.sh/chart: ingress-nginx-2.0.3
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/version: 0.32.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: controller
+  name: ingress-nginx-controller
+  namespace: ingress-nginx
+spec:
+  type: LoadBalancer
+  externalTrafficPolicy: Local
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: http
+    - name: https
+      port: 443
+      protocol: TCP
+      targetPort: https
+  selector:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/component: controller

--- a/payments/src/app.ts
+++ b/payments/src/app.ts
@@ -11,7 +11,8 @@ app.use(json());
 app.use(
     cookieSession({
         signed: false,
-        secure: process.env.NODE_ENV !== 'test'
+        //secure: process.env.NODE_ENV !== 'test'
+        secure: false
     })
 );
 app.use(currentUser);


### PR DESCRIPTION
Hotfixes for HTTPS and workaround for ingress-nginx on digital ocean: check https://github.com/digitalocean/digitalocean-cloud-controller-manager/blob/master/docs/controllers/services/examples/README.md#accessing-pods-over-a-managed-load-balancer-from-inside-the-cluster