### PR TITLE
Shows Id in characters overview page now

### DIFF
--- a/client/pages/characters/show.js
+++ b/client/pages/characters/show.js
@@ -6,7 +6,7 @@ const showCharacters = ({ currentUser, characters }) => {
     return (
       <tr key={character.id}>
         <td>{character.name}</td>
-        <td>{character.stats}</td>
+        <td>{character.id}</td>
         <td>
           <Link href="/characters/[characterId]" as={`/characters/${character.id}`}>
             <a>Details</a>
@@ -23,7 +23,7 @@ const showCharacters = ({ currentUser, characters }) => {
         <thead>
           <tr>
             <th>Name</th>
-            <th>Stats</th>
+            <th>Id</th>
             <th>Link</th>
           </tr>
         </thead>


### PR DESCRIPTION
Shows Id now instead the not populated stats value in character overview for easier access for endusers to copy/paste id for possible discord bots