### PR TITLE
Changed Dice API for discordId input

### DIFF
--- a/characters/src/helper/skillCheck.ts
+++ b/characters/src/helper/skillCheck.ts
@@ -5,13 +5,13 @@ import { findBestMatch } from 'string-similarity';
 
 const sensitivityTranslate = 0.1;
 
-export async function skillCheck(id: string, reqSkill: string, discordId?: string) {
-        
-    let character = await Character.findById(id);
-
-    if(discordId){      
-        let character = await Character.find({discordId: discordId});      
-    }
+export async function skillCheck(character: any,reqSkill: string) {
+    
+    
+    // let character = await Character.findById(id);    
+    // if(discordId){
+    //     let character = await Character.find({discordId: discordId});
+    // }
     
     const skills = [
         {name: 'Flying' , value: character?.skills?.Flying},
@@ -105,5 +105,15 @@ export async function skillCheck(id: string, reqSkill: string, discordId?: strin
     response.push(coreAttributes.find((item) => item.name === skillChecked?.thirdAttr)?.value);
     response.push(matchedSkill);
 
-    return response;
+    const attr = response.slice(1, 4);
+    const taw = response.slice(0,1);
+
+    const skillresponse = {
+        attr,
+        taw: taw[0],
+        mod: 0,
+        skill: response[4]  
+    }
+
+    return skillresponse;
 } 

--- a/characters/src/models/character.ts
+++ b/characters/src/models/character.ts
@@ -257,6 +257,8 @@ interface CharacterDoc extends mongoose.Document {
 }
 
 interface CharacterModel extends mongoose.Model<CharacterDoc> {
+  coreAttributes: any;
+  skills: any;
   build(attrs: CharacterAttrs): CharacterDoc;
 }
 

--- a/characters/src/routes/__test__/skills.test.ts
+++ b/characters/src/routes/__test__/skills.test.ts
@@ -18,10 +18,11 @@ it('returns 200 and response contains all stats', async () => {
         .expect(201);
 
     const skillCheck = await request(app)
-        .post(`/api/characters/skill/${response.body.id}`)
+        .post('/api/characters/skill')
         .set('Cookie', global.signin(userId))
         .send({
-            talent: 'Geography'
+            talent: 'Geography',
+            characterId: response.body.id
         })
         .expect(200);
 

--- a/characters/src/routes/skills.ts
+++ b/characters/src/routes/skills.ts
@@ -1,28 +1,22 @@
 import express, { Request, Response} from 'express';
 import { skillCheck } from '../helper/skillCheck';
+import { Character } from '../models/character';
 
 const router = express.Router();
 
-router.post('/api/characters/skill/:id', async (req: Request, res: Response) => {
+router.post('/api/characters/skill', async (req: Request, res: Response) => {
     
-    let id = req.params.id;
-
-    if(req.body.discordId){
-       id = req.body.discordId
+    if(req.body.characterId){
+        const character = await Character.findById(req.body.characterId);
+        const response = await skillCheck(character, req.body.talent);
+        res.status(200).send(response);
+    } else if(req.body.discordId) {
+        const character = await Character.findOne({discordId: req.body.discordId});
+        const response = await skillCheck(character, req.body.talent);
+        res.status(200).send(response);
+    } else {
+        res.status(400).send('No id given');
     }
-
-    const response = await skillCheck(req.params.id, req.body.talent, id);
-
-    const attr = response.slice(1, 4);
-    const taw = response.slice(0,1);
-
-    const skillresponse = {
-        attr,
-        taw: taw[0],
-        mod: 0,
-        skill: response[4]  
-    }
-    res.status(200).send(skillresponse);
 });
 
 export {router as skillsCharacterRouter } 


### PR DESCRIPTION
BREAKING CHANGE FOR DICE API

Now the api is api/characters/skill
and the id is given in the body like:
{
	"talent":"Sinnenschärfe",
	"discordId": "123456",
	"characterId": "5fb1142cd9d771008cc104bf"
}

one Id is enough, if given both characterId will be used
